### PR TITLE
delete: Info.msg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ add_message_files(
   FILES
   Feature.msg
   ImgData.msg
-  Info.msg
   LidarData.msg
   OdomData.msg
   RealTime.msg


### PR DESCRIPTION
catkin_makeを行った際に，errrorが発生していたので，使用していないInfo.msgファイルを消去しました．